### PR TITLE
Fix the bug where XCOM ability icons are not disabled under specific conditions

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/X2EventListener_Soldiers.uc
@@ -515,7 +515,15 @@ static function EventListenerReturn OverrideCanPurchaseAbility(
 	{
 		if (`XCOMHQ.HasFacilityByName('RecoveryCenter'))
 		{
-			Tuple.Data[13].b = true;
+			if (Tuple.Data[12].b)
+			{
+				Tuple.Data[13].b = true;
+			}
+			else
+			{
+				Tuple.Data[13].b = false;
+				Tuple.Data[14].i = 3;   // Reason: Not enough AP
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Fix the bug where XCOM ability icons remain highlighted and clickable even when there is not enough AP, assuming that the Training Center has been built.