### PR TITLE
Fix Skirmisher not being able to target MC'd enemies

### DIFF
--- a/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_SkirmisherAbilitySet_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_FactionBalance/Classes/X2Ability_SkirmisherAbilitySet_LW.uc
@@ -128,6 +128,7 @@ static function X2AbilityTemplate AddSkirmisherSlash()
 	AdjacencyCondition = new class'X2Condition_UnitProperty';
 	AdjacencyCondition.RequireWithinRange = true;
 	AdjacencyCondition.WithinRange = 144; //1.5 tiles in Unreal units, allows attacks on the diag
+	AdjacencyCondition.TreatMindControlledSquadmateAsHostile = true;
 	Template.AbilityTargetConditions.AddItem(AdjacencyCondition);
 
 	// Shooter Conditions


### PR DESCRIPTION
Fix Skirmisher's Ripjack Slash not being able to target MC'd enemies.

While testing, Justice, Wrath and Whiplash were found behaving the same way. Since these are base game abilities, they would be better fixed through the Community Highlander.

Reported by Mr. Mister here https://discord.com/channels/590853492084572170/590854029567852577/1174111576660377630, further tested by me.