### PR TITLE
Select target unit after using Command

### DIFF
--- a/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2Ability_OfficerAbilitySet.uc
+++ b/LongWarOfTheChosen/Src/LW_OfficerPack_Integrated/Classes/X2Ability_OfficerAbilitySet.uc
@@ -740,6 +740,7 @@ static function X2AbilityTemplate AddCommandAbility()
 	ActionPointEffect = new class'X2Effect_GrantActionPoints';
     ActionPointEffect.NumActionPoints = 1;
     ActionPointEffect.PointType = class'X2CharacterTemplateManager'.default.StandardActionPoint;
+    ActionPointEffect.bSelectUnit = true;
     Template.AddTargetEffect(ActionPointEffect);
 
 	ActionPointPersistEffect = new class'X2Effect_Persistent';


### PR DESCRIPTION
Modify Officer's Command to do what Teamwork does: After used, select the target unit.

Before this PR, the selected unit was the next one in squad select order.