### PR TITLE
Don't allow injured non-soldiers on liaison duty

### DIFF
--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIPersonnel_Liaison.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIPersonnel_Liaison.uc
@@ -58,7 +58,9 @@ function bool UnitAvailableForLiaisonDuty(StateObjectReference UnitRef)
     }
     else if (Unit.IsEngineer() || Unit.IsScientist())
     {
-        return !Unit.IsUnitCritical();
+        return (!Unit.IsUnitCritical()
+            && !Unit.IsInjured())
+        ;
     }
 
     return false;


### PR DESCRIPTION
Include an injury check when assessing Engineers' and Scientists' availability for liaison duty. Soldiers already had this since they obviously take wounds more often.