### PR TITLE
Add config for tech required to show recruit Psi & set it to none

### DIFF
--- a/LongWarOfTheChosen/Config/XComLW_UI.ini
+++ b/LongWarOfTheChosen/Config/XComLW_UI.ini
@@ -79,6 +79,7 @@ RECRUIT_FONT_SIZE_CTRL = 22					; Recruit screen font size for controller users.
 RECRUIT_Y_OFFSET_CTRL = -3					; Moves the stats up/down; negative numbers move up / positive numbers move down.
 RECRUIT_FONT_SIZE_MK = 20					; Recruit screen font size for mouse & keyboard users.
 RECRUIT_Y_OFFSET_MK = -2;					; Moves the stats up/down; negative numbers move up / positive numbers move down.
+RECRUIT_SHOW_PSI_TECH = ""					; The tech required to show Recruits' Psi stat. Use "AutopsySectoid" for old behaviour.
 
 [LW_Overhaul.UIScreenListener_UIStrategyMap]
 CYCLE_HAVENS_INSTANTLY = false				; When controller users cycle 'contacted' havens with the DPad, do we want the strategy map movement to be instantaneous or with acceleration/deceleration ?

--- a/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIRecruitmentListItem_LW.uc
+++ b/LongWarOfTheChosen/Src/LW_Overhaul/Classes/UIRecruitmentListItem_LW.uc
@@ -11,6 +11,7 @@ var config int RECRUIT_FONT_SIZE_CTRL;
 var config int RECRUIT_Y_OFFSET_CTRL;
 var config int RECRUIT_FONT_SIZE_MK;
 var config int RECRUIT_Y_OFFSET_MK;
+var config string RECRUIT_SHOW_PSI_TECH;
 
 simulated function InitRecruitItem(XComGameState_Unit Recruit)
 {
@@ -81,8 +82,15 @@ function AddIcons(XComGameState_Unit Recruit)
 {
 	local bool PsiStatIsVisible;
 	local float XLoc, YLoc, XDelta;
-	
-	PsiStatIsVisible = `XCOMHQ.IsTechResearched('AutopsySectoid');
+
+	if (RECRUIT_SHOW_PSI_TECH == "")
+	{
+		PsiStatIsVisible = true;
+	}
+	else
+	{
+		PsiStatIsVisible = `XCOMHQ.IsTechResearched(name(RECRUIT_SHOW_PSI_TECH));
+	}
 
 	// KDM : Stat icons, and their associated stat values, have to be manually placed.
 	XLoc = 97;


### PR DESCRIPTION
* Add config for `UIRecruitmentListItem_LW` that controls which tech is required to see recruits' Psi stat
* Set that config's default to `""` (no tech required), since with default soldier generation it can be calculated from other stats