### PR TITLE
Update Covering Fire loc

### DIFF
--- a/LongWarOfTheChosen/Localization/XComGame.int
+++ b/LongWarOfTheChosen/Localization/XComGame.int
@@ -5217,8 +5217,8 @@ LocPromotionPopupText="<Bullet/> Generate an explosive field of Psionic energy t
 ; End Translation
 
 [CoveringFire X2AbilityTemplate]
-LocLongDescription="Reaction shots confer an aim malus on enemies and can now be triggered by any enemy action, not just movement."
-LocPromotionPopupText="<Bullet/> If triggered by an enemy action, Covering Fire will trigger before the enemy action completes.<br/><Bullet/> In addition, having the Covering Fire ability confers a temporary aim penalty upon any units you take a reaction shot at, regardless of whether it was a covering fire shot or not.<br/>"
+LocLongDescription="Reaction shots now trigger on any hostile action, not just movement. Additionally, they confer a penalty of -<Ability:COVERING_FIRE_OFFENSE_MALUS> aim on targets, even on a miss."
+LocPromotionPopupText="<Bullet/> If triggered by an enemy action, Covering Fire will trigger before the enemy action completes.<br/><Bullet/> In addition, having the Covering Fire ability confers a penalty of -<Ability:COVERING_FIRE_OFFENSE_MALUS> aim upon any units you take a reaction shot at, regardless of whether it was a covering fire shot or not."
 
 [GrenadeLauncher_MG X2GrenadeLauncherTemplate]
 BriefSummary="Our Advanced Grenade Launcher uses magnetic technology to propel grenades further than our conventional launcher."

--- a/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
+++ b/LongWarOfTheChosen/Src/LW_PerkPack_Integrated/Classes/X2DownloadableContentInfo_LWPerkPack.uc
@@ -170,6 +170,9 @@ static function bool AbilityTagExpandHandler_CH(string InString, out string OutS
 		case 'CUTTHROAT_BONUS_CRIT_DAMAGE':
 			Outstring = string(class'X2Ability_PerkPackAbilitySet'.default.CUTTHROAT_BONUS_CRIT_DAMAGE);
 			return true;
+		case 'COVERING_FIRE_OFFENSE_MALUS':
+			Outstring = string(class'X2Ability_PerkPackAbilitySet'.default.COVERING_FIRE_OFFENSE_MALUS);
+			return true;
 		case 'GHOSTWALKER_DETECTION_RANGE_REDUCTION':
 			Outstring = string(int(class'X2Ability_PerkPackAbilitySet'.default.GHOSTWALKER_DETECTION_RANGE_REDUCTION * 100));
 			return true;


### PR DESCRIPTION
* Implement an ability tag expander for the aim malus
* Mention the aim malus in loc
* Mention that the aim malus applies even with misses