### PR TITLE
Fix Death Dealer and True Predator loc

### DIFF
--- a/LongWarOfTheChosen/Localization/LW_FactionBalance/XComGame.int
+++ b/LongWarOfTheChosen/Localization/LW_FactionBalance/XComGame.int
@@ -139,8 +139,8 @@ LocPromotionPopupText="<Bullet/> Improves the Skirmisher's mobility around the m
 ; LWOTC Needs Translation
 [Executioner X2AbilityTemplate]
 LocFriendlyName="Death Dealer"
-LocLongDescription="Grants +<Ability:DEATH_DEALER_CRIT/> crit chance. Critical shots against flanked targets while in Shadow deal double damage."
-LocHelpText="Grants +<Ability:DEATH_DEALER_CRIT/> crit chance. Critical shots against flanked targets while in Shadow deal double damage."
+LocLongDescription="Grants +<Ability:DEATH_DEALER_CRIT/> crit chance. When shooting flanked targets in Shadow, the critical damage bonus of your weapon is doubled."
+LocHelpText="Grants +<Ability:DEATH_DEALER_CRIT/> crit chance. When shooting flanked targets in Shadow, the critical damage bonus of your weapon is doubled."
 LocPromotionPopupText="<Bullet/> Use Shadow's increased mobility and smaller enemy detection radii to flank enemies and deal massive damage.<br/>"
 
 ; End Translation
@@ -234,5 +234,5 @@ LocPromotionPopupText="<Bullet/> Cheap Shot triggers if the target was previousl
 
 [TheBanisher_LW X2AbilityTemplate]
 LocFriendlyName="True Predator"
-LocLongDescription="Decreases the per-shot aim penalty of Banish by <Ability:THEBANISHER_HIT_BUFF> and decreases its cooldown by 1. Increases the range of Knife Enounters to <Ability:KNIFE_ENCOUNTERS_BANISHER_MAX_TILES/>. Death Dealer now doubles the damage of critical hits against unflankable targets."
-LocHelpText="Decreases the per-shot aim penalty of Banish by <Ability:THEBANISHER_HIT_BUFF> and decreases its cooldown by 1. Increases the range of Knife Enounters to <Ability:KNIFE_ENCOUNTERS_BANISHER_MAX_TILES/>. Death Dealer now doubles the damage of critical hits against unflankable targets."
+LocLongDescription="Decreases the per-shot aim penalty of Banish by <Ability:THEBANISHER_HIT_BUFF> and decreases its cooldown by 1. Increases the range of Knife Enounters to <Ability:KNIFE_ENCOUNTERS_BANISHER_MAX_TILES/>. Death Dealer now doubles the critical damage bonus of your weapon against unflankable targets."
+LocHelpText="Decreases the per-shot aim penalty of Banish by <Ability:THEBANISHER_HIT_BUFF> and decreases its cooldown by 1. Increases the range of Knife Enounters to <Ability:KNIFE_ENCOUNTERS_BANISHER_MAX_TILES/>. Death Dealer now doubles the critical damage bonus of your weapon against unflankable targets."


### PR DESCRIPTION
Death Dealer doesn't actually multiply all damage by 2 on crit. It only applies the critical damage bonus on your weapon one additional time.